### PR TITLE
Issue #461: LW2 Secondaries bridge has unbalanced item prices

### DIFF
--- a/CIBridge_LW2Secondary/Config/XComWeaponTuning.ini
+++ b/CIBridge_LW2Secondary/Config/XComWeaponTuning.ini
@@ -1,43 +1,83 @@
 [Arcthrower_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyAdventOfficer", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[Arcthrower_MG_Diff_3 X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="AutopsyAdventOfficer", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [Arcthrower_BM X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="AutopsySpectre", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[Arcthrower_BM_Diff_3 X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsySpectre", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=43), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 
 [CombatKnife_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyAdventStunLancer", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[CombatKnife_MG_Diff_3 X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="AutopsyAdventStunLancer", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [CombatKnife_BM X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[CombatKnife_BM_Diff_3 X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyArchon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=43), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 
 [LWGauntlet_MG X2MultiWeaponTemplate]
 Requirements=(RequiredTechs[0]="PlatedArmor", RequiredTechs[1]="AutopsyAdventPurifier", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[LWGauntlet_MG_Diff_3 X2MultiWeaponTemplate]
+Requirements=(RequiredTechs[0]="PlatedArmor", RequiredTechs[1]="AutopsyAdventPurifier", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [LWGauntlet_BM X2MultiWeaponTemplate]
+Requirements=(RequiredTechs[0]="PoweredArmor", RequiredTechs[1]="AutopsyAndromedon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[LWGauntlet_BM_Diff_3 X2MultiWeaponTemplate]
 Requirements=(RequiredTechs[0]="PoweredArmor", RequiredTechs[1]="AutopsyAndromedon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=43), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 
 [Holotargeter_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsyAdventMec", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[Holotargeter_MG_Diff_3 X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="AutopsyAdventMec", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [Holotargeter_BM X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="AutopsySectopod", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[Holotargeter_BM_Diff_3 X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AutopsySectopod", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=43), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 
 [SawedOffShotgun_MG X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="MagnetizedWeapons", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=12), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=2), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[SawedOffShotgun_MG_Diff_3 X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="MagnetizedWeapons", RequiredEngineeringScore=10, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=18), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))
 
 [SawedOffShotgun_BM X2WeaponTemplate]
+Requirements=(RequiredTechs[0]="AlloyCannon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
+Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=28), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=3), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=2))
+
+[SawedOffShotgun_BM_Diff_3 X2WeaponTemplate]
 Requirements=(RequiredTechs[0]="AlloyCannon", RequiredEngineeringScore=20, bVisibleIfPersonnelGatesNotMet=true)
 Cost=(ResourceCosts[0]=(ItemTemplateName="Supplies", Quantity=43), ResourceCosts[1]=(ItemTemplateName="AlienAlloy", Quantity=5), ResourceCosts[2]=(ItemTemplateName="EleriumDust", Quantity=3))


### PR DESCRIPTION
Lowered non-legend build costs by 1/3, kept old build costs as legend prices.